### PR TITLE
Fix CS0103: Variable 'meshFilter' scope error in SaveLODMeshesToAssets

### DIFF
--- a/Editor/LODGeneratorCore.cs
+++ b/Editor/LODGeneratorCore.cs
@@ -563,13 +563,14 @@ namespace Plugins.AutoLODGenerator.Editor
 
                     Mesh mesh = null;
                     bool isSkinned = false;
+                    MeshFilter meshFilter = null;
                     
                     if (renderer is SkinnedMeshRenderer skinnedRenderer)
                     {
                         mesh = skinnedRenderer.sharedMesh;
                         isSkinned = true;
                     }
-                    else if (renderer.TryGetComponent<MeshFilter>(out var meshFilter))
+                    else if (renderer.TryGetComponent<MeshFilter>(out meshFilter))
                     {
                         mesh = meshFilter.sharedMesh;
                     }


### PR DESCRIPTION
Hello! Thanks for this great tool.
I encountered a compilation error when installing the package in Unity.

The issue was caused by using out var meshFilter inside the else if condition block in the SaveLODMeshesToAssets method, which restricted the variable's scope. When the code tried to assign meshFilter.sharedMesh = savedMesh; later, it was out of scope.

I fixed this by declaring MeshFilter meshFilter = null; before the if/else block.
Tested and working perfectly in Unity 2022. Let me know if you need any further changes!