### PR TITLE
fix: plumb SimplificationOptions into mesh simplifier (#4)

### DIFF
--- a/Editor/LODGeneratorCore.cs
+++ b/Editor/LODGeneratorCore.cs
@@ -116,6 +116,8 @@ namespace Plugins.AutoLODGenerator.Editor
                 var totalLODCount = settings.includeCulledLevel ? settings.lodLevelCount + 1 : settings.lodLevelCount;
                 var lods = new LOD[totalLODCount];
 
+                var simplificationOptions = settings.CreateSimplificationOptions();
+
                 // Generate each LOD level
                 for (var i = 0; i < settings.lodLevelCount; i++)
                 {
@@ -131,7 +133,7 @@ namespace Plugins.AutoLODGenerator.Editor
                     else
                     {
                         // Simplify mesh for this LOD level
-                        lodMesh = SimplifyMesh(originalMesh, quality);
+                        lodMesh = SimplifyMesh(originalMesh, quality, simplificationOptions);
                         lodMesh.name = $"{originalMesh.name}_LOD{i}";
                     }
 
@@ -285,7 +287,8 @@ namespace Plugins.AutoLODGenerator.Editor
             float quality,
             string suffix = "_Simplified",
             bool saveMeshToAssets = false,
-            string meshSavePath = null)
+            string meshSavePath = null,
+            LODGeneratorSettings settings = null)
         {
             var result = new LODGenerationResult
             {
@@ -324,7 +327,7 @@ namespace Plugins.AutoLODGenerator.Editor
                 result.OriginalTriangleCount = GetTriangleCount(originalMesh);
 
                 // Simplify mesh
-                var simplifiedMesh = SimplifyMesh(originalMesh, quality);
+                var simplifiedMesh = SimplifyMesh(originalMesh, quality, settings?.CreateSimplificationOptions());
                 simplifiedMesh.name = $"{originalMesh.name}{suffix}";
 
                 result.LODVertexCounts = new[] { simplifiedMesh.vertexCount };
@@ -405,7 +408,7 @@ namespace Plugins.AutoLODGenerator.Editor
         /// <param name="sourceMesh">The source mesh to simplify.</param>
         /// <param name="quality">Quality factor (0.0 to 1.0).</param>
         /// <returns>A new simplified mesh.</returns>
-        public static Mesh SimplifyMesh(Mesh sourceMesh, float quality)
+        public static Mesh SimplifyMesh(Mesh sourceMesh, float quality, SimplificationOptions? options = null)
         {
             if (sourceMesh == null)
                 throw new ArgumentNullException(nameof(sourceMesh));
@@ -419,6 +422,8 @@ namespace Plugins.AutoLODGenerator.Editor
             }
 
             var meshSimplifier = new MeshSimplifier();
+            if (options.HasValue)
+                meshSimplifier.SimplificationOptions = options.Value;
             meshSimplifier.Initialize(sourceMesh);
             meshSimplifier.SimplifyMesh(quality);
 

--- a/Editor/LODGeneratorCore.cs
+++ b/Editor/LODGeneratorCore.cs
@@ -281,6 +281,9 @@ namespace Plugins.AutoLODGenerator.Editor
         /// <param name="suffix">Suffix to append to the object name.</param>
         /// <param name="saveMeshToAssets">Whether to save the mesh as an asset file.</param>
         /// <param name="meshSavePath">Custom path for saving mesh (optional).</param>
+        /// <param name="settings">Optional settings; only simplification-related fields
+        /// (preserveBorders, preserveSeams, preserveFoldovers, enableSmartLink,
+        /// vertexLinkDistance) are used. Validated before use.</param>
         /// <returns>Result containing the simplified mesh object and statistics.</returns>
         public static LODGenerationResult GenerateSimplifiedMesh(
             GameObject sourceObject,
@@ -327,6 +330,7 @@ namespace Plugins.AutoLODGenerator.Editor
                 result.OriginalTriangleCount = GetTriangleCount(originalMesh);
 
                 // Simplify mesh
+                settings?.Validate();
                 var simplifiedMesh = SimplifyMesh(originalMesh, quality, settings?.CreateSimplificationOptions());
                 simplifiedMesh.name = $"{originalMesh.name}{suffix}";
 
@@ -407,6 +411,9 @@ namespace Plugins.AutoLODGenerator.Editor
         /// </summary>
         /// <param name="sourceMesh">The source mesh to simplify.</param>
         /// <param name="quality">Quality factor (0.0 to 1.0).</param>
+        /// <param name="options">Optional simplification settings. If <c>null</c>, the mesh
+        /// simplifier uses its default simplification options; otherwise the provided options
+        /// are applied before simplification.</param>
         /// <returns>A new simplified mesh.</returns>
         public static Mesh SimplifyMesh(Mesh sourceMesh, float quality, SimplificationOptions? options = null)
         {


### PR DESCRIPTION
Closes #4.

## Summary
- `GenerateSimplifiedMesh` now accepts an optional `LODGeneratorSettings`, so the existing call in `AutoLODWindow.cs:771` (which already passed `_settings`) compiles again on Unity 6000.4.
- `SimplifyMesh` gained an optional `SimplificationOptions?` parameter and applies it to the `MeshSimplifier` before initialization.
- `GenerateLODGroup` builds `SimplificationOptions` once via `settings.CreateSimplificationOptions()` and forwards it to every per-LOD `SimplifyMesh` call.

## Why the extra wiring
The extra `_settings` argument at the call site came from commit `72b1b40`, which introduced a "Simplification Options" foldout (`enableSmartLink`, `vertexLinkDistance`, `preserveBorders`, `preserveSeams`, `preserveFoldovers`) but only populated `_settings` in the UI — the value was never threaded through to `MeshSimplifier`. Those toggles were silently ignored on both the main LOD tab and the Simplify tab. The missing parameter on `GenerateSimplifiedMesh` turned the dormant bug into a hard compile error. This PR both fixes the compile error and completes the original intent so the toggles actually affect output.

## Behavior change
The `preserveBorders` / `preserveSeams` / `preserveFoldovers` / `enableSmartLink` / `vertexLinkDistance` fields on `LODGeneratorSettings` now influence mesh simplification output on both paths. Existing 2-arg `SimplifyMesh` callers (`AutoLOD.cs:97, 330`, README example) continue to compile unchanged and retain their prior behavior (MeshSimplifier defaults).

## Test plan
- [ ] Open the project in Unity 6000.4 — verify the editor compiles (no CS1501 on `AutoLODWindow.cs:771`).
- [ ] Open the Auto LOD window and run **Generate LOD** on a mesh; toggle Preserve Borders / Preserve UV Seams and confirm the generated LOD meshes differ.
- [ ] Switch to the Simplify tab, expand "Simplification Options", and confirm the same toggles affect the simplified output.
- [ ] Regression: run **Generate LOD** with default settings and confirm vertex/triangle counts match the previous release within expected variance.