### PR TITLE
[codex] Support composite model roots for LOD generation

### DIFF
--- a/Editor/AutoLODWindow.cs
+++ b/Editor/AutoLODWindow.cs
@@ -879,7 +879,7 @@ namespace Plugins.AutoLODGenerator.Editor
 
                 EditorGUILayout.EndScrollView();
 
-                EditorGUILayout.LabelField("S = Skinned, M = Static Mesh", EditorStyles.miniLabel);
+                EditorGUILayout.LabelField("S = Skinned, M = Static Mesh, C = Composite", EditorStyles.miniLabel);
             }
 
             // Selection helpers

--- a/Editor/LODGeneratorCore.cs
+++ b/Editor/LODGeneratorCore.cs
@@ -57,6 +57,11 @@ namespace Plugins.AutoLODGenerator.Editor
                     return result;
                 }
 
+                if (rendererType == MeshRendererType.Composite)
+                {
+                    return GenerateCompositeLODGroup(sourceObject, settings, saveMeshesToAssets, meshSavePath);
+                }
+
                 settings.Validate();
 
                 // Get mesh and materials based on renderer type
@@ -206,6 +211,136 @@ namespace Plugins.AutoLODGenerator.Editor
             return result;
         }
 
+        private static LODGenerationResult GenerateCompositeLODGroup(
+            GameObject sourceObject,
+            LODGeneratorSettings settings,
+            bool saveMeshesToAssets = false,
+            string meshSavePath = null)
+        {
+            var result = new LODGenerationResult
+            {
+                SourceObject = sourceObject,
+                Success = false
+            };
+
+            try
+            {
+                settings.Validate();
+
+                var sourceRenderers = GetCompositeRendererData(sourceObject);
+                if (sourceRenderers.Count == 0)
+                {
+                    result.ErrorMessage = $"'{sourceObject.name}' does not have any child meshes to process.";
+                    return result;
+                }
+
+                result.OriginalVertexCount = GetTotalVertexCount(sourceRenderers);
+                result.OriginalTriangleCount = GetTotalTriangleCount(sourceRenderers);
+                result.LODVertexCounts = new int[settings.lodLevelCount];
+                result.LODTriangleCounts = new int[settings.lodLevelCount];
+
+                var generatedMeshes = new List<Mesh>();
+                var savedMeshPaths = saveMeshesToAssets ? new List<string>() : null;
+
+                if (saveMeshesToAssets)
+                {
+                    if (string.IsNullOrEmpty(meshSavePath))
+                    {
+                        meshSavePath = DefaultMeshSaveFolder;
+                    }
+                    EnsureDirectoryExists(meshSavePath);
+                }
+
+                var originalTransform = sourceObject.transform;
+                var lodGroupObject = new GameObject($"{sourceObject.name}_LODGroup")
+                {
+                    transform =
+                    {
+                        position = originalTransform.position,
+                        rotation = originalTransform.rotation,
+                        localScale = Vector3.one
+                    }
+                };
+                lodGroupObject.transform.SetParent(originalTransform.parent, true);
+
+                var lodGroup = lodGroupObject.AddComponent<LODGroup>();
+                var totalLODCount = settings.includeCulledLevel ? settings.lodLevelCount + 1 : settings.lodLevelCount;
+                var lods = new LOD[totalLODCount];
+                var simplificationOptions = settings.CreateSimplificationOptions();
+
+                for (var i = 0; i < settings.lodLevelCount; i++)
+                {
+                    var quality = settings.GetQualityFactor(i);
+                    var screenHeight = settings.GetScreenTransitionHeight(i);
+                    var levelRoot = CreateCompositeLevelRoot(sourceObject, lodGroupObject.transform, i);
+                    var transformMap = new Dictionary<Transform, Transform>
+                    {
+                        { originalTransform, levelRoot.transform }
+                    };
+                    var lodRenderers = new List<Renderer>();
+
+                    foreach (var sourceRenderer in sourceRenderers)
+                    {
+                        var lodMesh = i == 0
+                            ? sourceRenderer.Mesh
+                            : SimplifyMesh(sourceRenderer.Mesh, quality, simplificationOptions);
+
+                        if (i > 0)
+                        {
+                            lodMesh.name = $"{sourceRenderer.Mesh.name}_LOD{i}";
+                        }
+
+                        result.LODVertexCounts[i] += lodMesh.vertexCount;
+                        result.LODTriangleCounts[i] += GetTriangleCount(lodMesh);
+                        generatedMeshes.Add(lodMesh);
+
+                        if (saveMeshesToAssets && i > 0)
+                        {
+                            var meshName = GetRendererMeshAssetName(sourceObject, sourceRenderer.Renderer, $"LOD{i}");
+                            var savedPath = SaveMeshAsset(lodMesh, meshSavePath, meshName);
+                            if (!string.IsNullOrEmpty(savedPath))
+                            {
+                                savedMeshPaths.Add(savedPath);
+                                lodMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                            }
+                        }
+
+                        var targetTransform = EnsureMirroredTransform(
+                            originalTransform,
+                            sourceRenderer.Renderer.transform,
+                            levelRoot.transform,
+                            transformMap);
+                        var lodRenderer = CreateCompositeRenderer(sourceRenderer, targetTransform.gameObject, lodMesh);
+                        lodRenderers.Add(lodRenderer);
+                    }
+
+                    lods[i] = new LOD(screenHeight, lodRenderers.ToArray());
+                }
+
+                if (settings.includeCulledLevel)
+                {
+                    lods[settings.lodLevelCount] = new LOD(settings.culledTransitionHeight, Array.Empty<Renderer>());
+                }
+
+                lodGroup.SetLODs(lods);
+                lodGroup.RecalculateBounds();
+
+                Undo.RegisterCreatedObjectUndo(lodGroupObject, $"Generate LOD Group for {sourceObject.name}");
+
+                result.GeneratedMeshes = generatedMeshes.ToArray();
+                result.SavedMeshPaths = savedMeshPaths?.ToArray();
+                result.GeneratedLODGroup = lodGroupObject;
+                result.Success = true;
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = $"Error generating composite LOD group: {ex.Message}";
+                Debug.LogException(ex);
+            }
+
+            return result;
+        }
+
         private static Renderer CreateStaticLODObject(
             string baseName,
             Transform parent,
@@ -315,6 +450,17 @@ namespace Plugins.AutoLODGenerator.Editor
                     return result;
                 }
 
+                if (rendererType == MeshRendererType.Composite)
+                {
+                    return GenerateCompositeSimplifiedMesh(
+                        sourceObject,
+                        quality,
+                        suffix,
+                        saveMeshToAssets,
+                        meshSavePath,
+                        settings);
+                }
+
                 quality = Mathf.Clamp01(quality);
 
                 // Get mesh and materials based on renderer type
@@ -400,6 +546,112 @@ namespace Plugins.AutoLODGenerator.Editor
             catch (Exception ex)
             {
                 result.ErrorMessage = $"Error simplifying mesh: {ex.Message}";
+                Debug.LogException(ex);
+            }
+
+            return result;
+        }
+
+        private static LODGenerationResult GenerateCompositeSimplifiedMesh(
+            GameObject sourceObject,
+            float quality,
+            string suffix = "_Simplified",
+            bool saveMeshToAssets = false,
+            string meshSavePath = null,
+            LODGeneratorSettings settings = null)
+        {
+            var result = new LODGenerationResult
+            {
+                SourceObject = sourceObject,
+                Success = false
+            };
+
+            try
+            {
+                var sourceRenderers = GetCompositeRendererData(sourceObject);
+                if (sourceRenderers.Count == 0)
+                {
+                    result.ErrorMessage = $"'{sourceObject.name}' does not have any child meshes to process.";
+                    return result;
+                }
+
+                quality = Mathf.Clamp01(quality);
+                settings?.Validate();
+
+                result.OriginalVertexCount = GetTotalVertexCount(sourceRenderers);
+                result.OriginalTriangleCount = GetTotalTriangleCount(sourceRenderers);
+                result.LODVertexCounts = new[] { 0 };
+                result.LODTriangleCounts = new[] { 0 };
+
+                var generatedMeshes = new List<Mesh>();
+                var savedMeshPaths = saveMeshToAssets ? new List<string>() : null;
+
+                if (saveMeshToAssets)
+                {
+                    if (string.IsNullOrEmpty(meshSavePath))
+                    {
+                        meshSavePath = DefaultMeshSaveFolder;
+                    }
+                    EnsureDirectoryExists(meshSavePath);
+                }
+
+                var originalTransform = sourceObject.transform;
+                var simplifiedObject = new GameObject($"{sourceObject.name}{suffix}")
+                {
+                    transform =
+                    {
+                        position = originalTransform.position,
+                        rotation = originalTransform.rotation,
+                        localScale = originalTransform.localScale
+                    }
+                };
+
+                var transformMap = new Dictionary<Transform, Transform>
+                {
+                    { originalTransform, simplifiedObject.transform }
+                };
+
+                foreach (var sourceRenderer in sourceRenderers)
+                {
+                    var simplifiedMesh = SimplifyMesh(
+                        sourceRenderer.Mesh,
+                        quality,
+                        settings?.CreateSimplificationOptions());
+                    simplifiedMesh.name = $"{sourceRenderer.Mesh.name}{suffix}";
+
+                    result.LODVertexCounts[0] += simplifiedMesh.vertexCount;
+                    result.LODTriangleCounts[0] += GetTriangleCount(simplifiedMesh);
+                    generatedMeshes.Add(simplifiedMesh);
+
+                    if (saveMeshToAssets)
+                    {
+                        var meshName = GetRendererMeshAssetName(sourceObject, sourceRenderer.Renderer, suffix);
+                        var savedPath = SaveMeshAsset(simplifiedMesh, meshSavePath, meshName);
+                        if (!string.IsNullOrEmpty(savedPath))
+                        {
+                            savedMeshPaths.Add(savedPath);
+                            simplifiedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                        }
+                    }
+
+                    var targetTransform = EnsureMirroredTransform(
+                        originalTransform,
+                        sourceRenderer.Renderer.transform,
+                        simplifiedObject.transform,
+                        transformMap);
+                    CreateCompositeRenderer(sourceRenderer, targetTransform.gameObject, simplifiedMesh);
+                }
+
+                Undo.RegisterCreatedObjectUndo(simplifiedObject, $"Simplify {sourceObject.name}");
+
+                result.GeneratedMeshes = generatedMeshes.ToArray();
+                result.SavedMeshPaths = savedMeshPaths?.ToArray();
+                result.GeneratedLODGroup = simplifiedObject;
+                result.Success = true;
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = $"Error simplifying composite mesh: {ex.Message}";
                 Debug.LogException(ex);
             }
 
@@ -697,7 +949,7 @@ namespace Plugins.AutoLODGenerator.Editor
             for (var i = 0; i < result.GeneratedMeshes.Length; i++)
             {
                 var mesh = result.GeneratedMeshes[i];
-                if (mesh != null && i > 0) // Skip LOD0 as it's the original mesh
+                if (mesh != null && i > 0 && !AssetDatabase.Contains(mesh)) // Skip original/saved meshes
                 {
                     var path = SaveMeshAsset(mesh, folderPath, $"{baseName}_LOD{i}");
                     if (!string.IsNullOrEmpty(path))
@@ -748,6 +1000,11 @@ namespace Plugins.AutoLODGenerator.Editor
                 return MeshRendererType.MeshRenderer;
             }
 
+            if (GetCompositeRendererData(gameObject).Count > 0)
+            {
+                return MeshRendererType.Composite;
+            }
+
             return MeshRendererType.None;
         }
 
@@ -771,7 +1028,7 @@ namespace Plugins.AutoLODGenerator.Editor
             var rendererType = GetMeshRendererType(gameObject);
             if (rendererType == MeshRendererType.None)
             {
-                errorMessage = $"'{gameObject.name}' does not have a valid mesh. Requires MeshFilter+MeshRenderer or SkinnedMeshRenderer.";
+                errorMessage = $"'{gameObject.name}' does not have a valid mesh. Requires MeshFilter+MeshRenderer, SkinnedMeshRenderer, or child objects with valid mesh renderers.";
                 return false;
             }
 
@@ -812,6 +1069,11 @@ namespace Plugins.AutoLODGenerator.Editor
                 case MeshRendererType.MeshRenderer:
                     mesh = gameObject.GetComponent<MeshFilter>().sharedMesh;
                     break;
+                case MeshRendererType.Composite:
+                    var rendererData = GetCompositeRendererData(gameObject);
+                    return rendererData.Count == 0
+                        ? (-1, -1, MeshRendererType.None)
+                        : (GetTotalVertexCount(rendererData), GetTotalTriangleCount(rendererData), rendererType);
             }
 
             return mesh == null
@@ -822,6 +1084,161 @@ namespace Plugins.AutoLODGenerator.Editor
         #endregion
 
         #region Private Helpers
+
+        private sealed class SourceRendererData
+        {
+            public Renderer Renderer { get; set; }
+            public Mesh Mesh { get; set; }
+            public Material[] Materials { get; set; }
+            public MeshRendererType Type { get; set; }
+        }
+
+        private static List<SourceRendererData> GetCompositeRendererData(GameObject gameObject)
+        {
+            var rendererData = new List<SourceRendererData>();
+            if (gameObject == null)
+                return rendererData;
+
+            foreach (var renderer in gameObject.GetComponentsInChildren<Renderer>(true))
+            {
+                if (renderer is SkinnedMeshRenderer skinnedRenderer)
+                {
+                    if (skinnedRenderer.sharedMesh == null) continue;
+
+                    rendererData.Add(new SourceRendererData
+                    {
+                        Renderer = skinnedRenderer,
+                        Mesh = skinnedRenderer.sharedMesh,
+                        Materials = skinnedRenderer.sharedMaterials,
+                        Type = MeshRendererType.SkinnedMeshRenderer
+                    });
+                }
+                else if (renderer is MeshRenderer meshRenderer)
+                {
+                    if (!meshRenderer.TryGetComponent<MeshFilter>(out var meshFilter) ||
+                        meshFilter.sharedMesh == null)
+                    {
+                        continue;
+                    }
+
+                    rendererData.Add(new SourceRendererData
+                    {
+                        Renderer = meshRenderer,
+                        Mesh = meshFilter.sharedMesh,
+                        Materials = meshRenderer.sharedMaterials,
+                        Type = MeshRendererType.MeshRenderer
+                    });
+                }
+            }
+
+            return rendererData;
+        }
+
+        private static int GetTotalVertexCount(List<SourceRendererData> rendererData)
+        {
+            var vertexCount = 0;
+            foreach (var data in rendererData)
+                vertexCount += data.Mesh.vertexCount;
+            return vertexCount;
+        }
+
+        private static int GetTotalTriangleCount(List<SourceRendererData> rendererData)
+        {
+            var triangleCount = 0;
+            foreach (var data in rendererData)
+                triangleCount += GetTriangleCount(data.Mesh);
+            return triangleCount;
+        }
+
+        private static GameObject CreateCompositeLevelRoot(GameObject sourceObject, Transform parent, int lodIndex)
+        {
+            var levelRoot = new GameObject($"{sourceObject.name}_LOD{lodIndex}");
+            levelRoot.transform.SetParent(parent, false);
+            levelRoot.transform.localPosition = Vector3.zero;
+            levelRoot.transform.localRotation = Quaternion.identity;
+            levelRoot.transform.localScale = sourceObject.transform.localScale;
+            return levelRoot;
+        }
+
+        private static Transform EnsureMirroredTransform(
+            Transform sourceRoot,
+            Transform sourceTransform,
+            Transform targetRoot,
+            Dictionary<Transform, Transform> transformMap)
+        {
+            if (sourceTransform == sourceRoot)
+                return targetRoot;
+
+            if (transformMap.TryGetValue(sourceTransform, out var existingTransform))
+                return existingTransform;
+
+            var targetParent = EnsureMirroredTransform(
+                sourceRoot,
+                sourceTransform.parent,
+                targetRoot,
+                transformMap);
+
+            var targetObject = new GameObject(sourceTransform.name);
+            var targetTransform = targetObject.transform;
+            targetTransform.SetParent(targetParent, false);
+            targetTransform.localPosition = sourceTransform.localPosition;
+            targetTransform.localRotation = sourceTransform.localRotation;
+            targetTransform.localScale = sourceTransform.localScale;
+
+            transformMap[sourceTransform] = targetTransform;
+            return targetTransform;
+        }
+
+        private static Renderer CreateCompositeRenderer(
+            SourceRendererData sourceRenderer,
+            GameObject targetObject,
+            Mesh mesh)
+        {
+            if (sourceRenderer.Type == MeshRendererType.SkinnedMeshRenderer)
+            {
+                var sourceSkinnedRenderer = (SkinnedMeshRenderer)sourceRenderer.Renderer;
+                var targetRenderer = targetObject.AddComponent<SkinnedMeshRenderer>();
+                targetRenderer.sharedMesh = mesh;
+                targetRenderer.sharedMaterials = sourceRenderer.Materials;
+                targetRenderer.bones = sourceSkinnedRenderer.bones;
+                targetRenderer.rootBone = sourceSkinnedRenderer.rootBone;
+                targetRenderer.quality = sourceSkinnedRenderer.quality;
+                targetRenderer.localBounds = sourceSkinnedRenderer.localBounds;
+                CopyRendererSettings(sourceSkinnedRenderer, targetRenderer);
+                targetRenderer.updateWhenOffscreen = sourceSkinnedRenderer.updateWhenOffscreen;
+                return targetRenderer;
+            }
+
+            var meshFilter = targetObject.AddComponent<MeshFilter>();
+            meshFilter.sharedMesh = mesh;
+
+            var meshRenderer = targetObject.AddComponent<MeshRenderer>();
+            meshRenderer.sharedMaterials = sourceRenderer.Materials;
+            CopyRendererSettings(sourceRenderer.Renderer, meshRenderer);
+            return meshRenderer;
+        }
+
+        private static string GetRendererMeshAssetName(GameObject sourceObject, Renderer renderer, string suffix)
+        {
+            var relativePath = GetRelativeTransformPath(sourceObject.transform, renderer.transform)
+                .Replace('/', '_');
+            return $"{sourceObject.name}_{relativePath}_{suffix}";
+        }
+
+        private static string GetRelativeTransformPath(Transform root, Transform transform)
+        {
+            var names = new List<string>();
+            var current = transform;
+
+            while (current != null && current != root)
+            {
+                names.Add(current.name);
+                current = current.parent;
+            }
+
+            names.Reverse();
+            return names.Count == 0 ? root.name : string.Join("_", names);
+        }
 
         /// <summary>
         /// Gets the triangle count of a mesh without allocating a copy of the index buffer.

--- a/Editor/LODGeneratorCore.cs
+++ b/Editor/LODGeneratorCore.cs
@@ -99,6 +99,7 @@ namespace Plugins.AutoLODGenerator.Editor
                     {
                         meshSavePath = DefaultMeshSaveFolder;
                     }
+                    meshSavePath = GetObjectMeshSaveFolder(meshSavePath, sourceObject.name);
                     EnsureDirectoryExists(meshSavePath);
                     result.SavedMeshPaths = new string[settings.lodLevelCount];
                 }
@@ -248,6 +249,7 @@ namespace Plugins.AutoLODGenerator.Editor
                     {
                         meshSavePath = DefaultMeshSaveFolder;
                     }
+                    meshSavePath = GetObjectMeshSaveFolder(meshSavePath, sourceObject.name);
                     EnsureDirectoryExists(meshSavePath);
                 }
 
@@ -491,6 +493,7 @@ namespace Plugins.AutoLODGenerator.Editor
                     {
                         meshSavePath = DefaultMeshSaveFolder;
                     }
+                    meshSavePath = GetObjectMeshSaveFolder(meshSavePath, sourceObject.name);
                     EnsureDirectoryExists(meshSavePath);
 
                     var savedPath = SaveMeshAsset(simplifiedMesh, meshSavePath, $"{sourceObject.name}{suffix}");
@@ -592,6 +595,7 @@ namespace Plugins.AutoLODGenerator.Editor
                     {
                         meshSavePath = DefaultMeshSaveFolder;
                     }
+                    meshSavePath = GetObjectMeshSaveFolder(meshSavePath, sourceObject.name);
                     EnsureDirectoryExists(meshSavePath);
                 }
 
@@ -812,11 +816,12 @@ namespace Plugins.AutoLODGenerator.Editor
                 folderPath = DefaultMeshSaveFolder;
             }
 
+            var baseName = lodGroupObject.name.Replace("_LODGroup", "");
+            folderPath = GetObjectMeshSaveFolder(folderPath, baseName);
             EnsureDirectoryExists(folderPath);
 
             var savedPaths = new List<string>();
             var lods = lodGroup.GetLODs();
-            var baseName = lodGroupObject.name.Replace("_LODGroup", "");
 
             for (var lodIndex = 0; lodIndex < lods.Length; lodIndex++)
             {
@@ -945,6 +950,7 @@ namespace Plugins.AutoLODGenerator.Editor
 
             var paths = new List<string>();
             var baseName = result.SourceObject != null ? result.SourceObject.name : "Mesh";
+            folderPath = GetObjectMeshSaveFolder(folderPath, baseName);
 
             for (var i = 0; i < result.GeneratedMeshes.Length; i++)
             {
@@ -960,6 +966,44 @@ namespace Plugins.AutoLODGenerator.Editor
             }
 
             return paths.ToArray();
+        }
+
+        private static string GetObjectMeshSaveFolder(string rootFolderPath, string objectName)
+        {
+            if (string.IsNullOrEmpty(rootFolderPath))
+            {
+                rootFolderPath = DefaultMeshSaveFolder;
+            }
+
+            var folderName = SanitizeFolderName(objectName);
+            if (string.IsNullOrEmpty(folderName))
+            {
+                folderName = "Mesh";
+            }
+
+            var normalizedRoot = rootFolderPath.TrimEnd('/', '\\');
+            var lastSegment = Path.GetFileName(normalizedRoot);
+            if (string.Equals(lastSegment, folderName, StringComparison.OrdinalIgnoreCase))
+            {
+                return normalizedRoot;
+            }
+
+            return $"{normalizedRoot}/{folderName}";
+        }
+
+        private static string SanitizeFolderName(string folderName)
+        {
+            if (string.IsNullOrWhiteSpace(folderName))
+            {
+                return "Mesh";
+            }
+
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                folderName = folderName.Replace(c, '_');
+            }
+
+            return folderName.Trim();
         }
 
         private static void EnsureDirectoryExists(string path)

--- a/Editor/LODGeneratorCore.cs
+++ b/Editor/LODGeneratorCore.cs
@@ -145,7 +145,6 @@ namespace Plugins.AutoLODGenerator.Editor
 
                     result.LODVertexCounts[i] = lodMesh.vertexCount;
                     result.LODTriangleCounts[i] = GetTriangleCount(lodMesh);
-                    result.GeneratedMeshes[i] = lodMesh;
 
                     // Save mesh to assets if requested
                     if (saveMeshesToAssets && i > 0)
@@ -156,9 +155,15 @@ namespace Plugins.AutoLODGenerator.Editor
                         // Reload the saved mesh
                         if (!string.IsNullOrEmpty(savedPath))
                         {
-                            lodMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                            var savedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                            if (savedMesh != null)
+                            {
+                                lodMesh = savedMesh;
+                            }
                         }
                     }
+
+                    result.GeneratedMeshes[i] = lodMesh;
 
                     // Create LOD GameObject based on renderer type
                     Renderer lodRenderer;
@@ -294,7 +299,6 @@ namespace Plugins.AutoLODGenerator.Editor
 
                         result.LODVertexCounts[i] += lodMesh.vertexCount;
                         result.LODTriangleCounts[i] += GetTriangleCount(lodMesh);
-                        generatedMeshes.Add(lodMesh);
 
                         if (saveMeshesToAssets && i > 0)
                         {
@@ -303,9 +307,15 @@ namespace Plugins.AutoLODGenerator.Editor
                             if (!string.IsNullOrEmpty(savedPath))
                             {
                                 savedMeshPaths.Add(savedPath);
-                                lodMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                                var savedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                                if (savedMesh != null)
+                                {
+                                    lodMesh = savedMesh;
+                                }
                             }
                         }
+
+                        generatedMeshes.Add(lodMesh);
 
                         var targetTransform = EnsureMirroredTransform(
                             originalTransform,
@@ -484,7 +494,6 @@ namespace Plugins.AutoLODGenerator.Editor
 
                 result.LODVertexCounts = new[] { simplifiedMesh.vertexCount };
                 result.LODTriangleCounts = new[] { GetTriangleCount(simplifiedMesh) };
-                result.GeneratedMeshes = new[] { simplifiedMesh };
 
                 // Save mesh to assets if requested
                 if (saveMeshToAssets)
@@ -502,9 +511,15 @@ namespace Plugins.AutoLODGenerator.Editor
                     // Reload the saved mesh
                     if (!string.IsNullOrEmpty(savedPath))
                     {
-                        simplifiedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                        var savedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                        if (savedMesh != null)
+                        {
+                            simplifiedMesh = savedMesh;
+                        }
                     }
                 }
+
+                result.GeneratedMeshes = new[] { simplifiedMesh };
 
                 // Create simplified GameObject
                 var simplifiedObject = new GameObject($"{sourceObject.name}{suffix}")
@@ -625,7 +640,6 @@ namespace Plugins.AutoLODGenerator.Editor
 
                     result.LODVertexCounts[0] += simplifiedMesh.vertexCount;
                     result.LODTriangleCounts[0] += GetTriangleCount(simplifiedMesh);
-                    generatedMeshes.Add(simplifiedMesh);
 
                     if (saveMeshToAssets)
                     {
@@ -634,9 +648,15 @@ namespace Plugins.AutoLODGenerator.Editor
                         if (!string.IsNullOrEmpty(savedPath))
                         {
                             savedMeshPaths.Add(savedPath);
-                            simplifiedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                            var savedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(savedPath);
+                            if (savedMesh != null)
+                            {
+                                simplifiedMesh = savedMesh;
+                            }
                         }
                     }
+
+                    generatedMeshes.Add(simplifiedMesh);
 
                     var targetTransform = EnsureMirroredTransform(
                         originalTransform,
@@ -955,7 +975,7 @@ namespace Plugins.AutoLODGenerator.Editor
             for (var i = 0; i < result.GeneratedMeshes.Length; i++)
             {
                 var mesh = result.GeneratedMeshes[i];
-                if (mesh != null && i > 0 && !AssetDatabase.Contains(mesh)) // Skip original/saved meshes
+                if (mesh != null && !AssetDatabase.Contains(mesh))
                 {
                     var path = SaveMeshAsset(mesh, folderPath, $"{baseName}_LOD{i}");
                     if (!string.IsNullOrEmpty(path))
@@ -1044,7 +1064,7 @@ namespace Plugins.AutoLODGenerator.Editor
                 return MeshRendererType.MeshRenderer;
             }
 
-            if (GetCompositeRendererData(gameObject).Count > 0)
+            if (HasCompositeRenderers(gameObject))
             {
                 return MeshRendererType.Composite;
             }
@@ -1135,6 +1155,29 @@ namespace Plugins.AutoLODGenerator.Editor
             public Mesh Mesh { get; set; }
             public Material[] Materials { get; set; }
             public MeshRendererType Type { get; set; }
+        }
+
+        private static bool HasCompositeRenderers(GameObject gameObject)
+        {
+            if (gameObject == null)
+                return false;
+
+            foreach (var renderer in gameObject.GetComponentsInChildren<Renderer>(true))
+            {
+                if (renderer is SkinnedMeshRenderer skinnedRenderer)
+                {
+                    if (skinnedRenderer.sharedMesh != null)
+                        return true;
+                }
+                else if (renderer is MeshRenderer meshRenderer &&
+                         meshRenderer.TryGetComponent<MeshFilter>(out var meshFilter) &&
+                         meshFilter.sharedMesh != null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static List<SourceRendererData> GetCompositeRendererData(GameObject gameObject)

--- a/Editor/Tests/LODGeneratorCoreTests.cs
+++ b/Editor/Tests/LODGeneratorCoreTests.cs
@@ -98,6 +98,25 @@ namespace Plugins.AutoLODGenerator.Editor.Tests
         }
 
         [Test]
+        public void ValidateForLODGeneration_WithChildMeshRenderer_ReturnsTrue()
+        {
+            var root = new GameObject("TestCompositeRoot");
+            var child = new GameObject("MeshChild");
+            child.transform.SetParent(root.transform);
+            child.AddComponent<MeshFilter>().sharedMesh = new Mesh();
+            child.AddComponent<MeshRenderer>();
+
+            var isValid = LODGeneratorCore.ValidateForLODGeneration(root, out var errorMessage);
+            var rendererType = LODGeneratorCore.GetMeshRendererType(root);
+
+            Assert.IsTrue(isValid);
+            Assert.IsNull(errorMessage);
+            Assert.AreEqual(MeshRendererType.Composite, rendererType);
+
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
         public void GetMeshStatistics_WithNullObject_ReturnsNegativeValues()
         {
             var (vertices, triangles, type) = LODGeneratorCore.GetMeshStatistics(null);
@@ -125,6 +144,37 @@ namespace Plugins.AutoLODGenerator.Editor.Tests
             Assert.AreEqual(MeshRendererType.MeshRenderer, type);
             
             Object.DestroyImmediate(go);
+        }
+
+        [Test]
+        public void GetMeshStatistics_WithCompositeMesh_ReturnsCombinedValues()
+        {
+            var meshA = new Mesh();
+            meshA.vertices = new Vector3[6];
+            meshA.triangles = new[] { 0, 1, 2, 3, 4, 5 };
+
+            var meshB = new Mesh();
+            meshB.vertices = new Vector3[3];
+            meshB.triangles = new[] { 0, 1, 2 };
+
+            var root = new GameObject("TestCompositeStats");
+            var childA = new GameObject("MeshChildA");
+            childA.transform.SetParent(root.transform);
+            childA.AddComponent<MeshFilter>().sharedMesh = meshA;
+            childA.AddComponent<MeshRenderer>();
+
+            var childB = new GameObject("MeshChildB");
+            childB.transform.SetParent(root.transform);
+            childB.AddComponent<MeshFilter>().sharedMesh = meshB;
+            childB.AddComponent<MeshRenderer>();
+
+            var (vertices, triangles, type) = LODGeneratorCore.GetMeshStatistics(root);
+
+            Assert.AreEqual(9, vertices);
+            Assert.AreEqual(3, triangles);
+            Assert.AreEqual(MeshRendererType.Composite, type);
+
+            Object.DestroyImmediate(root);
         }
     }
 

--- a/Editor/Tests/LODGeneratorCoreTests.cs
+++ b/Editor/Tests/LODGeneratorCoreTests.cs
@@ -100,20 +100,28 @@ namespace Plugins.AutoLODGenerator.Editor.Tests
         [Test]
         public void ValidateForLODGeneration_WithChildMeshRenderer_ReturnsTrue()
         {
+            var mesh = new Mesh();
             var root = new GameObject("TestCompositeRoot");
-            var child = new GameObject("MeshChild");
-            child.transform.SetParent(root.transform);
-            child.AddComponent<MeshFilter>().sharedMesh = new Mesh();
-            child.AddComponent<MeshRenderer>();
 
-            var isValid = LODGeneratorCore.ValidateForLODGeneration(root, out var errorMessage);
-            var rendererType = LODGeneratorCore.GetMeshRendererType(root);
+            try
+            {
+                var child = new GameObject("MeshChild");
+                child.transform.SetParent(root.transform);
+                child.AddComponent<MeshFilter>().sharedMesh = mesh;
+                child.AddComponent<MeshRenderer>();
 
-            Assert.IsTrue(isValid);
-            Assert.IsNull(errorMessage);
-            Assert.AreEqual(MeshRendererType.Composite, rendererType);
+                var isValid = LODGeneratorCore.ValidateForLODGeneration(root, out var errorMessage);
+                var rendererType = LODGeneratorCore.GetMeshRendererType(root);
 
-            Object.DestroyImmediate(root);
+                Assert.IsTrue(isValid);
+                Assert.IsNull(errorMessage);
+                Assert.AreEqual(MeshRendererType.Composite, rendererType);
+            }
+            finally
+            {
+                Object.DestroyImmediate(root);
+                Object.DestroyImmediate(mesh);
+            }
         }
 
         [Test]
@@ -158,23 +166,31 @@ namespace Plugins.AutoLODGenerator.Editor.Tests
             meshB.triangles = new[] { 0, 1, 2 };
 
             var root = new GameObject("TestCompositeStats");
-            var childA = new GameObject("MeshChildA");
-            childA.transform.SetParent(root.transform);
-            childA.AddComponent<MeshFilter>().sharedMesh = meshA;
-            childA.AddComponent<MeshRenderer>();
 
-            var childB = new GameObject("MeshChildB");
-            childB.transform.SetParent(root.transform);
-            childB.AddComponent<MeshFilter>().sharedMesh = meshB;
-            childB.AddComponent<MeshRenderer>();
+            try
+            {
+                var childA = new GameObject("MeshChildA");
+                childA.transform.SetParent(root.transform);
+                childA.AddComponent<MeshFilter>().sharedMesh = meshA;
+                childA.AddComponent<MeshRenderer>();
 
-            var (vertices, triangles, type) = LODGeneratorCore.GetMeshStatistics(root);
+                var childB = new GameObject("MeshChildB");
+                childB.transform.SetParent(root.transform);
+                childB.AddComponent<MeshFilter>().sharedMesh = meshB;
+                childB.AddComponent<MeshRenderer>();
 
-            Assert.AreEqual(9, vertices);
-            Assert.AreEqual(3, triangles);
-            Assert.AreEqual(MeshRendererType.Composite, type);
+                var (vertices, triangles, type) = LODGeneratorCore.GetMeshStatistics(root);
 
-            Object.DestroyImmediate(root);
+                Assert.AreEqual(9, vertices);
+                Assert.AreEqual(3, triangles);
+                Assert.AreEqual(MeshRendererType.Composite, type);
+            }
+            finally
+            {
+                Object.DestroyImmediate(root);
+                Object.DestroyImmediate(meshA);
+                Object.DestroyImmediate(meshB);
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Transform complex 3D meshes into optimized LOD groups with just a few clicks. Pe
 ### Mesh Support
 - **Static Meshes** - Full support for MeshFilter + MeshRenderer objects
 - **Skinned Meshes** - Full support for SkinnedMeshRenderer (animated characters)
+- **Composite Models** - Supports imported prefab/model roots with mesh renderers on child objects
 - **Save to Assets** - Export generated meshes as reusable .asset files
 
 ### Workflow
@@ -369,7 +370,7 @@ A: Yes, if you enable "Save Meshes to Assets", the meshes are saved as `.asset` 
 
 **Q: What mesh formats are supported?**
 
-A: Any mesh that Unity can import (FBX, OBJ, DAE, etc.) as long as it's a valid mesh with triangles.
+A: Any mesh that Unity can import (FBX, OBJ, DAE, etc.) as long as it's a valid mesh with triangles. Imported prefab roots are supported when their child objects contain valid MeshRenderer or SkinnedMeshRenderer components, which covers common GLB/glTF and USDZ workflows after an appropriate Unity importer has converted the file into GameObjects.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Enable **Save Meshes to Assets** in the Save Options section to:
 - Export generated LOD meshes as `.asset` files
 - Reuse meshes across multiple prefabs
 - Reduce scene file size
-- **Default save location**: `Assets/GeneratedLODs/`
+- **Default save location**: `Assets/GeneratedLODs/<ModelName>/`
 
 ### Skinned Mesh Support
 


### PR DESCRIPTION
## Summary

Adds support for imported model/prefab roots whose renderable meshes live on child objects, which is the common shape for GLB/glTF imports and USDZ workflows after an importer converts the file into Unity GameObjects.

## What changed

- Detect root objects with child `MeshRenderer` or `SkinnedMeshRenderer` components as `Composite` models.
- Generate LOD groups by mirroring the child transform hierarchy for each LOD level and simplifying each child mesh independently.
- Save generated LOD mesh assets under a per-model subfolder, for example `Assets/GeneratedLODs/<ModelName>/`.
- Support composite roots in single-mesh simplification, batch selection labels, statistics, and validation.
- Document composite model behavior without claiming native file parsing for GLB/USDZ.
- Add tests for composite validation and aggregate mesh statistics.

## Validation

- `git diff --check` passed.
- Unity editmode tests were attempted with Unity 6000.3.11f1 batchmode, but Unity failed before running tests due licensing initialization failure and produced no test results file.