### PR TITLE
[codex] Fix automatic release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     name: Tag Current Version
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag_created: ${{ steps.tag.outputs.created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,6 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Validate version consistency
+        id: version
         run: |
           PKG_VERSION=$(jq -r '.version' package.json)
           CHANGELOG_FIRST=""
@@ -47,13 +51,16 @@ jobs:
           fi
 
           echo "VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag when missing
+        id: tag
         run: |
           TAG="v${VERSION}"
 
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists; skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -61,15 +68,19 @@ jobs:
           git push origin "${TAG}" || {
             if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
               echo "Tag ${TAG} already exists after push attempt; skipping."
+              echo "created=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "::error::Failed to push tag ${TAG}."
             exit 1
           }
+          echo "created=true" >> "$GITHUB_OUTPUT"
 
   release-default-branch:
     name: Create Release (Default Branch)
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: >
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      needs.tag-default-branch.outputs.tag_created == 'true'
     needs: tag-default-branch
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -75,3 +75,26 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.version.outputs.new }}"
           git tag "v${{ steps.version.outputs.new }}"
           git push origin "HEAD:refs/heads/${DEFAULT_BRANCH}" --tags
+
+      - name: Extract changelog for new version
+        run: |
+          VERSION="${{ steps.version.outputs.new }}"
+          CHANGELOG=$(awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$CHANGELOG" ]; then
+            echo "::error::No changelog section found for version $VERSION."
+            exit 1
+          fi
+
+          echo "$CHANGELOG" > release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ steps.version.outputs.new }}"
+          name: "v${{ steps.version.outputs.new }}"
+          body_path: release_notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,8 +172,8 @@ Releases are automated with GitHub Actions once a new version lands on the defau
 
 1. **Changelog and version** — The version in `package.json` must match the **first** non-`[Unreleased]` section heading in `CHANGELOG.md` (for example `## [2.2.0]`). CI enforces this on every push and pull request.
 2. **Merge to default branch** — Once that version change is merged, the **Release** workflow checks whether `v<package.json version>` exists. If it does not, the workflow creates and pushes the tag automatically.
-3. **GitHub Release** — The `v*` tag trigger in the same workflow validates tag/package consistency, extracts that version’s changelog section, and publishes the GitHub Release.
-4. **Optional helper** — You can still run **Version Bump** (Actions → *Version Bump* → Run workflow) to bump patch/minor/major, scaffold changelog headings, and push the bump commit/tag in one action.
+3. **GitHub Release** — When the **Release** workflow creates a new tag, it extracts that version’s changelog section and publishes the GitHub Release in the same run. If the tag already exists, the release job is skipped.
+4. **Optional helper** — You can still run **Version Bump** (Actions → *Version Bump* → Run workflow) to bump patch/minor/major, scaffold changelog headings, push the bump commit/tag, and publish the GitHub Release in one action.
 
 If `CHANGELOG.md` is edited by hand, update `package.json` to the same version so CI stays green. Automation requires `GITHUB_TOKEN` to have `contents: write` so tags and releases can be created.
 


### PR DESCRIPTION
## Summary

Fixes the release automation so version bumping publishes a GitHub Release directly instead of relying on a follow-up workflow trigger from `GITHUB_TOKEN` pushes.

## What changed

- The **Version Bump** workflow now extracts the new changelog section and creates the GitHub Release after pushing the bump commit/tag.
- The **Release** workflow now exposes whether it actually created a tag and only runs the default-branch release job for newly created tags.
- Updated release documentation in `CONTRIBUTING.md` to match the real flow.

## Root cause

`GITHUB_TOKEN` pushes from one workflow do not reliably trigger another workflow run, so a manually triggered version bump could push the version/tag without creating a release. Separately, normal merges that do not change `package.json` kept targeting the existing release tag, which made the Release workflow look successful while not producing a new release.

## Validation

- Parsed `.github/workflows/release.yml` and `.github/workflows/version-bump.yml` with Ruby YAML parser.
- `git diff --check` passed.